### PR TITLE
compile error: void ambiguous for Foreign.void 

### DIFF
--- a/src/Player/OpenAL.hs
+++ b/src/Player/OpenAL.hs
@@ -117,7 +117,7 @@ lastInd p c = do
 process :: (Chunkable a) => Int -> Source -> [Buffer] -> [Buffer] -> MVar (Maybe (Chunk a)) -> MVar () -> IO ()
 process sampleRate' pSource freeBuffers usedBuffers mVarMaybeChunk mVarReply = do
   mChunk <- takeMVar mVarMaybeChunk
-  void $ reply mChunk (\chunk -> do
+  Foreign.void $ reply mChunk (\chunk -> do
     mInd <- lastInd (/= 0) chunk -- we aren't sent chunks with leading zeros
     (f,u) <- reply mInd (\ind -> do  
       (buff,newFree,newUsed) <- if null freeBuffers 


### PR DESCRIPTION
[3 of 5] Compiling Player.OpenAL    ( src/Player/OpenAL.hs, dist/build/yampasynt
h-openal/yampasynth-openal-tmp/Player/OpenAL.o )

src/Player/OpenAL.hs:120:3:
    Ambiguous occurrence `void'
    It could refer to either`Foreign.void',
                             imported from Foreign at src/Player/OpenAL.hs:19:1-14
                          or `Control.Monad.void',
                             imported from Control.Monad at src/Player/OpenAL.hs:21:1-20
